### PR TITLE
Add into_inner method to access inner buffer

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -145,6 +145,10 @@ impl<R: io::Read> BomPeeker<R> {
         self.bom = Some(PossibleBom { bytes: buf, len: bom_len });
         Ok(self.bom.unwrap())
     }
+
+    pub fn into_inner(self) -> R {
+        self.rdr
+    }
 }
 
 impl<R: io::Read> io::Read for BomPeeker<R> {


### PR DESCRIPTION
This implements a `into_inner` method that returns the inner buffer.

My use case for this was needing to seek the inner reader, I tried implementing `Seek` but there were complications when clearing all the internal buffers, so I thought it would be easier to just expose this method and then seek the reader myself, which could cover other use cases.